### PR TITLE
[DC-9031] - Update anchor tags to make use of latest Gov.uk hyperlink style class

### DIFF
--- a/app/views/bta_list_partial.scala.html
+++ b/app/views/bta_list_partial.scala.html
@@ -48,7 +48,7 @@
                 <td class="govuk-table__cell">
                 @defining({
                     val messageSubject = ensureEscaped(message.subject)
-                    val subjectAsBoldIfUnread = if(message.readTime.isDefined) "<span class='underline black-text govuk-body'>" + messageSubject + "</span>" else "<span class='underline black-text govuk-body bold'>" + messageSubject + "</span>"
+                    val subjectAsBoldIfUnread = if(message.readTime.isDefined) "<span class='govuk-link'>" + messageSubject + "</span>" else "<span class='govuk-link bold'>" + messageSubject + "</span>"
                     val subjectWithCounter = if (message.counter.isDefined && message.counter.get != 1) subjectAsBoldIfUnread + "&nbsp;&nbsp;<span class='non-breaking message-counter govuk-body'>" + "(" + message.counter.get + ")" + "</span>" else subjectAsBoldIfUnread
                     val subject = if(message.sentInError) subjectWithCounter + "&nbsp;&nbsp;-&nbsp;&nbsp;<span class='non-breaking sent-in-error govuk-body'>" + Messages("withdrawn") + "</span>" else subjectWithCounter
                     val messageUrl = s"messages/${encryptAndEncode.generateEncryptedUrl(message.id, btaBaseUrl)}"

--- a/app/views/list_partial.scala.html
+++ b/app/views/list_partial.scala.html
@@ -177,9 +177,9 @@
                             val sender = getSenderName(message)
                             val messageLang = message.lang
                             val senderSpan = if(message.readTime.isEmpty) {
-                                    <span class="govuk-!-font-weight-bold black-text govuk-body">{sender}</span>
+                                    <span class="govuk-!-font-weight-bold govuk-link--no-underline">{sender}</span>
                             } else {
-                                    <span class="black-text govuk-body">{sender}</span>
+                                    <span class="govuk-link--no-underline">{sender}</span>
                             }
 
                             <a href={messageUrl(message)} class="no--underline" data-sso="false" lang={messageLang}>
@@ -209,7 +209,7 @@
                                     )
                                     </span>
                             } else {
-                                    <span class="underline black-text govuk-body">{messageRead}</span>
+                                    <span class="govuk-link">{messageRead}</span>
                             }
                             val messageLang = message.lang
                             <a href={messageUrl(message)} class="no--underline message-subject govuk-link" data-sso="false" lang={messageLang}>

--- a/app/views/list_partial.scala.html
+++ b/app/views/list_partial.scala.html
@@ -197,7 +197,7 @@
                         <span>@{
                             val messageSubject = ensureEscaped(message.subject)
                             val messageRead = if(message.readTime.isEmpty) {
-                                    <span class="govuk-!-font-weight-bold black-text govuk-body">{messageSubject}</span>
+                                    <span class="govuk-!-font-weight-bold govuk-link">{messageSubject}</span>
                             } else {
                                 messageSubject
                             }

--- a/app/views/list_partial.scala.html
+++ b/app/views/list_partial.scala.html
@@ -202,7 +202,7 @@
                                 messageSubject
                             }
                             val subjectWithCounter = if(message.counter.isDefined && message.counter.get != 1) {
-                                    <span class="underline black-text govuk-body">{messageRead}</span>
+                                    <span class="govuk-link">{messageRead}</span>
                                     <span class="message-counter non-breaking govuk-body">
                                     (
                                     {message.counter.get}

--- a/app/views/list_partial.scala.html
+++ b/app/views/list_partial.scala.html
@@ -108,13 +108,13 @@
 
         .message-counter {
             font-size: 90%;
-            color: blue;
+            color: #1a65a6;
             padding-left: 1ex;
         }
 
         .non-breaking {
             font-size: 90%;
-            color: blue;
+            color: #1a65a6;
         }
 
         .marker-column {
@@ -182,7 +182,7 @@
                                     <span class="govuk-link--no-underline">{sender}</span>
                             }
 
-                            <a href={messageUrl(message)} class="no--underline" data-sso="false" lang={messageLang}>
+                            <a href={messageUrl(message)} class="govuk-link" data-sso="false" lang={messageLang}>
                                 {senderSpan}
                             </a>
                         }

--- a/app/views/list_partial.scala.html
+++ b/app/views/list_partial.scala.html
@@ -108,13 +108,13 @@
 
         .message-counter {
             font-size: 90%;
-            color: #6F777B;
+            color: blue;
             padding-left: 1ex;
         }
 
         .non-breaking {
             font-size: 90%;
-            color: #6F777B;
+            color: blue;
         }
 
         .marker-column {

--- a/app/views/message_inbox_link.scala.html
+++ b/app/views/message_inbox_link.scala.html
@@ -20,4 +20,4 @@
 @messageCount.filter(_.count > 0).map { count =>
   <p class="govuk-body-s font-xsmall messages" role="alert"><span id="unreadMessages" class="highlight-block--red govuk-body">@count.count @messages("unread.lowercase")</span> Notification@if(count.count > 1){s}</p>
 }
-<a href="@messagesInboxUrl" class="go-to-messages govuk-link" data-journey-click="messages:Click:Go to your messages" >@messages("go.inbox")</a>
+<a href="@messagesInboxUrl" class="govuk-link" data-journey-click="messages:Click:Go to your messages" >@messages("go.inbox")</a>

--- a/it/test/MessagesISpec.scala
+++ b/it/test/MessagesISpec.scala
@@ -423,9 +423,9 @@ class MessagesISpec extends MessageFrontendISpec with Inspectors {
 
   trait AuthenticatedUserMessageCount extends TestCase {
     val utr = SaUtr("123456789")
-    val b1 = """<span class="underline black-text govuk-body">"""
-    val bta_b1 = """<span class="underline black-text govuk-body bold">"""
-    val b2 = """<span class="govuk-!-font-weight-bold black-text govuk-body">"""
+    val b1 = """<span class="govuk-link">"""
+    val bta_b1 = """<span class="govuk-link bold">"""
+    val b2 = """<span class="govuk-!-font-weight-bold govuk-link">"""
     val a = """</span>"""
   }
 }

--- a/test/views/html/bta_list_partial_Spec.scala
+++ b/test/views/html/bta_list_partial_Spec.scala
@@ -19,6 +19,9 @@ package views.html
 import com.typesafe.config.ConfigFactory
 import helpers.LanguageHelper
 import model.{ Encoder, EncryptAndEncode, MessageListItem }
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -32,12 +35,14 @@ class bta_list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with Mocki
 
   implicit val messages: Messages = messagesInEnglish()
   implicit val lang: Lang = langEn
-  lazy val applicationCrypto = app.injector.instanceOf[ApplicationCrypto]
-  val encryptAndEncode = new EncryptAndEncode(applicationCrypto) {
+
+  lazy val applicationCrypto: ApplicationCrypto = app.injector.instanceOf[ApplicationCrypto]
+  val encryptAndEncode: EncryptAndEncode = new EncryptAndEncode(applicationCrypto) {
     override lazy val encoder: Encoder = new Encoder {
       override def encryptAndEncode(value: String) = s"encoded(encrypted($value))"
     }
   }
+
   "bta_list_partial" should {
 
     val Unread = None
@@ -58,6 +63,8 @@ class bta_list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with Mocki
         Html(""),
         encryptAndEncode
       )
+
+      shouldContainCorrectLinksStyleClassAndValue(html.body)
 
       html.body must (
         include("Unread") and
@@ -82,6 +89,8 @@ class bta_list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with Mocki
         encryptAndEncode
       )
 
+      shouldContainCorrectLinksStyleClassAndValue(html.body)
+
       html.body must (
         include("marker-column__marker") and
           include("visuallyhidden") and
@@ -105,9 +114,21 @@ class bta_list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with Mocki
         encryptAndEncode
       )
 
+      shouldContainCorrectLinksStyleClassAndValue(html.body)
+
       html.body must not include "Unread"
       html.body must include("Read")
       html.body must include("""<caption class="govuk-visually-hidden">Messages</caption>""")
+    }
+
+    def shouldContainCorrectLinksStyleClassAndValue(htmlBody: String): Unit = {
+      val htmlDoc: Document = Jsoup.parse(htmlBody)
+
+      val msgDetailsLinks: Elements = htmlDoc.getElementsByClass("link--no-underline")
+      val spanElement = msgDetailsLinks.get(0).getElementsByTag("span")
+
+      spanElement.attr("class") must include("govuk-link")
+      spanElement.text() must be("Leaving self assessment")
     }
   }
 }

--- a/test/views/html/list_partial_Spec.scala
+++ b/test/views/html/list_partial_Spec.scala
@@ -38,6 +38,7 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
 
   implicit val messages: Messages = messagesInEnglish()
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = engRequest
+
   lazy val applicationCrypto: ApplicationCrypto = app.injector.instanceOf[ApplicationCrypto]
   val encryptAndEncode: EncryptAndEncode = new EncryptAndEncode(applicationCrypto) {
     override lazy val encoder: Encoder = new Encoder {
@@ -88,7 +89,7 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
       "message counter is 2" in {
         val html = callListPartial(maybeReadTime = Unread, messageCounter = Some(2))
 
-        shouldContainCorrectLinksStyleClassAndValue(html.body)
+        shouldContainCorrectLinksStyleClassAndValue(html.body, true)
 
         html.body must (
           include("Unread") and
@@ -98,14 +99,24 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
       }
     }
 
-    "generate all field for read message" in {
-      val html = callListPartial(maybeReadTime = Read)
+    "generate all field for read message" when {
 
-      shouldContainCorrectLinksStyleClassAndValue(html.body)
-      html.body must not include "Unread"
+      "message counter is unavailable" in {
+        val html = callListPartial(maybeReadTime = Read)
+
+        shouldContainCorrectLinksStyleClassAndValue(html.body)
+        html.body must not include "Unread"
+      }
+
+      "message counter is 2" in {
+        val html = callListPartial(maybeReadTime = Read)
+
+        shouldContainCorrectLinksStyleClassAndValue(html.body)
+        html.body must not include "Unread"
+      }
     }
 
-    def shouldContainCorrectLinksStyleClassAndValue(htmlBody: String): Unit = {
+    def shouldContainCorrectLinksStyleClassAndValue(htmlBody: String, isUnreadMsg: Boolean = false): Unit = {
       val htmlDoc: Document = Jsoup.parse(htmlBody)
 
       val senderNameAndDescriptionLinks: Elements = htmlDoc.getElementsByClass("no--underline")
@@ -120,7 +131,11 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
         msgDescriptionLinkSpanElement.getElementsByClass("govuk-link").get(0).text()
 
       senderNameLinkSpanElementValue must be("HMRC")
-      msgDescriptionLinkSpanElementValue must be("Leaving self assessment")
+      if (isUnreadMsg) {
+        msgDescriptionLinkSpanElementValue must be("Leaving self assessment ( 2 )")
+      } else {
+        msgDescriptionLinkSpanElementValue must be("Leaving self assessment")
+      }
     }
   }
 }

--- a/test/views/html/list_partial_Spec.scala
+++ b/test/views/html/list_partial_Spec.scala
@@ -19,6 +19,9 @@ package views.html
 import config.AppConfig
 import helpers.LanguageHelper
 import model.{ Encoder, EncryptAndEncode, MessageListItem }
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -35,8 +38,8 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
 
   implicit val messages: Messages = messagesInEnglish()
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = engRequest
-  lazy val applicationCrypto = app.injector.instanceOf[ApplicationCrypto]
-  val encryptAndEncode = new EncryptAndEncode(applicationCrypto) {
+  lazy val applicationCrypto: ApplicationCrypto = app.injector.instanceOf[ApplicationCrypto]
+  val encryptAndEncode: EncryptAndEncode = new EncryptAndEncode(applicationCrypto) {
     override lazy val encoder: Encoder = new Encoder {
       override def encryptAndEncode(value: String) = s"encoded(encrypted($value))"
     }
@@ -49,7 +52,7 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
     val appConfig = mock[AppConfig]
     val testUrlBuilder = new PortalUrlBuilder(appConfig)
 
-    def callListPartial(maybeReadTime: Option[Instant]): Html =
+    def callListPartial(maybeReadTime: Option[Instant], messageCounter: Option[Int] = None): Html =
       views.html.list_partial(
         ptaBaseUrl = "/somePtaBaseUrl",
         messageItems = Seq(
@@ -59,7 +62,8 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
             validFrom = LocalDate.parse("2014-08-14"),
             taxpayerName = None,
             readTime = maybeReadTime,
-            sentInError = false
+            sentInError = false,
+            counter = messageCounter
           )
         ),
         urlBuilder = testUrlBuilder,
@@ -68,19 +72,55 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
         encryptAndEncode = encryptAndEncode
       )
 
-    "generate all field for unread message" in {
-      val html = callListPartial(maybeReadTime = Unread)
-      html.body must (
-        include("Unread") and
-          include("Leaving self assessment") and
-          include("14 August 2014")
-      )
+    "generate all field for unread message" when {
+      "message counter is unavailable" in {
+        val html = callListPartial(maybeReadTime = Unread)
+
+        shouldContainCorrectLinksStyleClassAndValue(html.body)
+
+        html.body must (
+          include("Unread") and
+            include("Leaving self assessment") and
+            include("14 August 2014")
+        )
+      }
+
+      "message counter is 2" in {
+        val html = callListPartial(maybeReadTime = Unread, messageCounter = Some(2))
+
+        shouldContainCorrectLinksStyleClassAndValue(html.body)
+
+        html.body must (
+          include("Unread") and
+            include("Leaving self assessment") and
+            include("14 August 2014")
+        )
+      }
     }
 
     "generate all field for read message" in {
       val html = callListPartial(maybeReadTime = Read)
 
+      shouldContainCorrectLinksStyleClassAndValue(html.body)
       html.body must not include "Unread"
+    }
+
+    def shouldContainCorrectLinksStyleClassAndValue(htmlBody: String): Unit = {
+      val htmlDoc: Document = Jsoup.parse(htmlBody)
+
+      val senderNameAndDescriptionLinks: Elements = htmlDoc.getElementsByClass("no--underline")
+
+      val senderNameLinkSpanElement = senderNameAndDescriptionLinks.get(0)
+      val msgDescriptionLinkSpanElement = senderNameAndDescriptionLinks.get(1)
+
+      val senderNameLinkSpanElementValue =
+        senderNameLinkSpanElement.getElementsByClass("govuk-link--no-underline").get(0).text()
+
+      val msgDescriptionLinkSpanElementValue =
+        msgDescriptionLinkSpanElement.getElementsByClass("govuk-link").get(0).text()
+
+      senderNameLinkSpanElementValue must be("HMRC")
+      msgDescriptionLinkSpanElementValue must be("Leaving self assessment")
     }
   }
 }

--- a/test/views/html/list_partial_Spec.scala
+++ b/test/views/html/list_partial_Spec.scala
@@ -53,26 +53,6 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
     val appConfig = mock[AppConfig]
     val testUrlBuilder = new PortalUrlBuilder(appConfig)
 
-    def callListPartial(maybeReadTime: Option[Instant], messageCounter: Option[Int] = None): Html =
-      views.html.list_partial(
-        ptaBaseUrl = "/somePtaBaseUrl",
-        messageItems = Seq(
-          MessageListItem(
-            id = "",
-            subject = "Leaving self assessment",
-            validFrom = LocalDate.parse("2014-08-14"),
-            taxpayerName = None,
-            readTime = maybeReadTime,
-            sentInError = false,
-            counter = messageCounter
-          )
-        ),
-        urlBuilder = testUrlBuilder,
-        saUtr = Some("someSaUtr"),
-        taxIdentifiersPartial = Html(""),
-        encryptAndEncode = encryptAndEncode
-      )
-
     "generate all field for unread message" when {
       "message counter is unavailable" in {
         val html = callListPartial(maybeReadTime = Unread)
@@ -115,6 +95,26 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
         html.body must not include "Unread"
       }
     }
+
+    def callListPartial(maybeReadTime: Option[Instant], messageCounter: Option[Int] = None): Html =
+      views.html.list_partial(
+        ptaBaseUrl = "/somePtaBaseUrl",
+        messageItems = Seq(
+          MessageListItem(
+            id = "",
+            subject = "Leaving self assessment",
+            validFrom = LocalDate.parse("2014-08-14"),
+            taxpayerName = None,
+            readTime = maybeReadTime,
+            sentInError = false,
+            counter = messageCounter
+          )
+        ),
+        urlBuilder = testUrlBuilder,
+        saUtr = Some("someSaUtr"),
+        taxIdentifiersPartial = Html(""),
+        encryptAndEncode = encryptAndEncode
+      )
 
     def shouldContainCorrectLinksStyleClassAndValue(htmlBody: String, isUnreadMsg: Boolean = false): Unit = {
       val htmlDoc: Document = Jsoup.parse(htmlBody)

--- a/test/views/html/list_partial_Spec.scala
+++ b/test/views/html/list_partial_Spec.scala
@@ -68,7 +68,6 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
 
       "message counter is 2" in {
         val html = callListPartial(maybeReadTime = Unread, messageCounter = Some(2))
-
         shouldContainCorrectLinksStyleClassAndValue(html.body, true)
 
         html.body must (
@@ -119,7 +118,7 @@ class list_partial_Spec extends PlaySpec with GuiceOneAppPerSuite with MockitoSu
     def shouldContainCorrectLinksStyleClassAndValue(htmlBody: String, isUnreadMsg: Boolean = false): Unit = {
       val htmlDoc: Document = Jsoup.parse(htmlBody)
 
-      val senderNameAndDescriptionLinks: Elements = htmlDoc.getElementsByClass("no--underline")
+      val senderNameAndDescriptionLinks: Elements = htmlDoc.getElementsByClass("govuk-link")
 
       val senderNameLinkSpanElement = senderNameAndDescriptionLinks.get(0)
       val msgDescriptionLinkSpanElement = senderNameAndDescriptionLinks.get(1)


### PR DESCRIPTION
Description - Update existing anchor tag style class 'underline black-text govuk-body' to 'govuk-link'

Apart from make use of 'govuk-link' below has been done as part of this PR

- make use of style class 'govuk-link--no-underline'
- remove obsolete style class 'go-to-messages' from message_inbox_link
- add tests

Note:- There is still lots of room for improvement by making use of other standard style classes and move the logic out of this view. But  will be done as part of separate refactoring ticket.